### PR TITLE
doc_extract: output json instead of python dict to stdout.

### DIFF
--- a/bin/doc_extract/doc_extract/driver.py
+++ b/bin/doc_extract/doc_extract/driver.py
@@ -90,14 +90,11 @@ class Driver(object):
         if self.shuffle:
             random.shuffle(contents)
 
-        if self.output:
-            try:
-                with open(self.output, "w") as fout:
-                    json.dump(contents, fout)
-            except Exception as ex:
-                print(f"Unable to write to output {ex}")
-        else:
-            print(contents, file=sys.stdout)
+        try:
+            with open(self.output, "w") if self.output else sys.stdout as fout:
+                json.dump(contents, fout)
+        except Exception as ex:
+            print(f"Unable to write to output {ex}")
 
 
 def main():


### PR DESCRIPTION
Fixes #4. Most of the time python dicts look like json but not always.

* bin/doc_extract/doc_extract/driver.py (Driver.run)