### PR TITLE
doc_extract: Fix parsing repo urls from stdin.

### DIFF
--- a/bin/doc_extract/doc_extract/driver.py
+++ b/bin/doc_extract/doc_extract/driver.py
@@ -58,7 +58,7 @@ class Driver(object):
             except Exception as ex:
                 print(f"Failed to open sourcefile {ex}")
         else:
-            paths = sys.stdin.readlines()
+            paths = [x.strip() for x in sys.stdin.readlines()]
 
         contents: List[Dict[str, Any]] = list()
 


### PR DESCRIPTION
Fixes #5.

* doc_extract/driver.py (Driver.run): Strip whitespace including newlines from each line of stdin.