### PR TITLE
Make `darglint2` package executable.

### DIFF
--- a/darglint2/__main__.py
+++ b/darglint2/__main__.py
@@ -1,0 +1,3 @@
+from .driver import main
+
+main()


### PR DESCRIPTION
This adds the module `darglint2.__main__` allowing a user to run `python -m darglint2` in the same way as running `darglint2` directly.
Fixes #27.

* darglint2/__main__.py : Call `.driver.main`.